### PR TITLE
Add indexes to AuditLog for faster performance

### DIFF
--- a/src/DataDog/AuditBundle/Entity/AuditLog.php
+++ b/src/DataDog/AuditBundle/Entity/AuditLog.php
@@ -6,7 +6,10 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- * @ORM\Table(name="audit_logs")
+ * @ORM\Table(name="audit_logs", indexes={
+ *     @ORM\Index(name="idx_audit_logs_logged_at", columns={"logged_at"}),
+ *     @ORM\Index(name="idx_audit_logs_tbl", columns={"tbl"})
+ * })
  */
 class AuditLog
 {

--- a/src/DataDog/AuditBundle/Resources/config/doctrine/AuditLog.orm.xml
+++ b/src/DataDog/AuditBundle/Resources/config/doctrine/AuditLog.orm.xml
@@ -1,10 +1,14 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
   http://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
 
   <entity name="DataDog\AuditBundle\Entity\AuditLog" table="audit_logs">
 
+    <indexes>
+      <index name="idx_audit_logs_logged_at" columns="logged_at"/>
+      <index name="idx_audit_logs_tbl" columns="tbl"/>
+    </indexes>
     <id name="id" type="integer" column="id">
       <generator strategy="IDENTITY"/>
     </id>

--- a/src/DataDog/AuditBundle/Resources/config/doctrine/AuditLog.orm.yml
+++ b/src/DataDog/AuditBundle/Resources/config/doctrine/AuditLog.orm.yml
@@ -1,6 +1,11 @@
 DataDog\AuditBundle\Entity\AuditLog:
   type: entity
   table: audit_logs
+  indexes:
+    idx_audit_logs_logged_at:
+      columns: [ logged_at ]
+    idx_audit_logs_tbl:
+        columns: [ tbl ]
   id:
     id:
       type: bigint


### PR DESCRIPTION
Added indexes on audit log table `tbl` and `logged_at` columns to improve performance pagination and sorting performance when a huge number of entries exist in database